### PR TITLE
Also prevent dirt paths. Inform player when this happens. Add German texts.

### DIFF
--- a/src/main/resources/assets/nostrip/lang/de_de.json
+++ b/src/main/resources/assets/nostrip/lang/de_de.json
@@ -1,0 +1,9 @@
+{
+  "text.nostrip.toggle": "Rindenentfernung %s",
+  "text.nostrip.on" : "§a§lEin",
+  "text.nostrip.off" : "§c§lAus",
+  "text.nostrip.prevented" : "§aNoStrip has diese Aktion verhindert",
+  "text.nostrip.enableby" : "§aNoStrip has diese Aktion verhindert, %s§a schaltet ein",
+  "key.nostrip.togglestrip": "Rinde Entfernen umschalten",
+  "category.nostrip.title" : "No Strip"
+}

--- a/src/main/resources/assets/nostrip/lang/en_us.json
+++ b/src/main/resources/assets/nostrip/lang/en_us.json
@@ -2,6 +2,8 @@
   "text.nostrip.toggle": "Stripping %s",
   "text.nostrip.on" : "§a§lOn",
   "text.nostrip.off" : "§c§lOff",
+  "text.nostrip.prevented" : "§aNoStrip has prevented this action",
+  "text.nostrip.enableby" : "§aNoStrip has prevented this action, press %s§a to toggle",
   "key.nostrip.togglestrip": "Toggle Log Stripping",
   "category.nostrip.title" : "No Strip"
 }


### PR DESCRIPTION
This prevents accidential dirt path creation as well as log stripping. Inform players when this happens, and tell them the key they bound NoStrip to. Include German translation of strings.

I also check for dirt blocks in addition to grass, as 1.17 allows turning dirt to paths (the mod works well with 20w46a btw).
