### PR TITLE
Rename the generated config file to match the mods name

### DIFF
--- a/src/main/java/us/potatoboy/nostrip/client/NostripClient.java
+++ b/src/main/java/us/potatoboy/nostrip/client/NostripClient.java
@@ -39,7 +39,7 @@ public class NostripClient implements ClientModInitializer {
     public void onInitializeClient() {
 
         // Create config object from JSON
-        config = NoStripConfig.loadConfig(new File(FabricLoader.getInstance().getConfigDir() + "/htm_config.json"));
+        config = NoStripConfig.loadConfig(new File(FabricLoader.getInstance().getConfigDir() + "/nostrip_config.json"));
         doStrip = config.isStripping();
 
         UseBlockCallback.EVENT.register(((playerEntity, world, hand, blockHitResult) -> {
@@ -66,7 +66,7 @@ public class NostripClient implements ClientModInitializer {
             return ActionResult.PASS;
         }));
         ClientLifecycleEvents.CLIENT_STOPPING.register((MinecraftClient client) -> {
-            config.saveConfig(new File(FabricLoader.getInstance().getConfigDir() + "/htm_config.json"));
+            config.saveConfig(new File(FabricLoader.getInstance().getConfigDir() + "/nostrip_config.json"));
         });
 
         keyBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding(


### PR DESCRIPTION
Hey there!

I've noticed that the config file for this mod is named "**htm_config.json**". Since this isn't "Hey that's mine" it's a little confusing – at least I was wondering for a second why the server plugin would save a config on the client side.

I've attached a small fix just changing the code to have the file be named "**nostrip_config.json**" instead for clarity.